### PR TITLE
Update external WebGPU example to the latest API

### DIFF
--- a/resources/external/testPerfWebGPU.html
+++ b/resources/external/testPerfWebGPU.html
@@ -74,57 +74,50 @@
         async function init(canvas) {
             const vertexShaderGLSL = `
                 [[block]] struct SceneUniforms {
-                    [[offset(0)]] viewProjectionMatrix : mat4x4<f32>;
+                    viewProjectionMatrix : mat4x4<f32>;
                 };
-                [[binding(0), set(0)]] var<uniform> sceneUniforms : SceneUniforms;
+                [[binding(0), group(0)]] var<uniform> sceneUniforms : SceneUniforms;
                 
                 [[block]] struct MeshUniforms {
-                    [[offset(0)]] worldMatrix : mat4x4<f32>;
+                    worldMatrix : mat4x4<f32>;
                 };
-                [[binding(0), set(2)]] var<uniform> meshUniforms : MeshUniforms;
+                [[binding(0), group(2)]] var<uniform> meshUniforms : MeshUniforms;
                 
-                [[location(0)]] var<in> position : vec4<f32>;
-                
-                [[builtin(position)]] var<out> Position : vec4<f32>;
-                [[location(0)]] var<out> fragPosition: vec4<f32>;
+                struct VertexOutput {
+                    [[builtin(position)]] Position : vec4<f32>;
+                    [[location(0)]] fragPosition: vec4<f32>;
+                };
                 
                 [[stage(vertex)]]
-                fn main() -> void {
-                    fragPosition = 0.5 * (position + vec4<f32>(1.0, 1.0, 1.0, 1.0));
-                    Position = sceneUniforms.viewProjectionMatrix * meshUniforms.worldMatrix * position;
-                    return;
+                fn main([[location(0)]] position : vec4<f32>) -> VertexOutput {
+                    var out: VertexOutput;
+                    out.fragPosition = 0.5 * (position + vec4<f32>(1.0, 1.0, 1.0, 1.0));
+                    out.Position = sceneUniforms.viewProjectionMatrix * meshUniforms.worldMatrix * position;
+                    return out;
                 }
                 `;
 
             const fragmentShaderGLSL = `
                 [[block]] struct MaterialUniforms {
-                    [[offset(0)]] color : vec4<f32>;
+                    color : vec4<f32>;
                 };
-                [[binding(0), set(1)]] var<uniform> materialUniforms : MaterialUniforms;
+                [[binding(0), group(1)]] var<uniform> materialUniforms : MaterialUniforms;
 
-                [[location(0)]] var<in> fragPosition: vec4<f32>;
-                [[location(0)]] var<out> outColor : vec4<f32>;
-                
                 [[stage(fragment)]]
-                fn main() -> void {
-                    outColor =  materialUniforms.color;
-                    return;
+                fn main() -> [[location(0)]] vec4<f32> {
+                    return materialUniforms.color;
                 }
                 `;
 
             const fragmentShader2GLSL = `
                 [[block]] struct MaterialUniforms {
-                    [[offset(0)]] color : vec4<f32>;
+                    color : vec4<f32>;
                 };
-                [[binding(0), set(1)]] var<uniform> materialUniforms : MaterialUniforms;
-
-                [[location(0)]] var<in> fragPosition: vec4<f32>;
-                [[location(0)]] var<out> outColor : vec4<f32>;
+                [[binding(0), group(1)]] var<uniform> materialUniforms : MaterialUniforms;
                 
                 [[stage(fragment)]]
-                fn main() -> void {
-                    outColor =  vec4<f32>(materialUniforms.color.r, materialUniforms.color.g, 1.0, 1.0);
-                    return;
+                fn main() -> [[location(0)]] vec4<f32> {
+                    return vec4<f32>(materialUniforms.color.r, materialUniforms.color.g, 1.0, 1.0);
                 }
                 `;
 
@@ -395,12 +388,13 @@
 
             const renderPassDescriptor = {
                 colorAttachments: [{
-                    attachment: undefined, // Assigned later
+                    view: undefined, // Assigned later
 
                     loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+                    storeOp: "store",
                 }],
                 depthStencilAttachment: {
-                    attachment: depthTexture.createView(),
+                    view: depthTexture.createView(),
 
                     depthLoadValue: 1.0,
                     depthStoreOp: "store",
@@ -412,7 +406,7 @@
             return function frame(timestamp) {
                 const commandEncoder = device.createCommandEncoder();
 
-                renderPassDescriptor.colorAttachments[0].attachment = swapChain.getCurrentTexture().createView();
+                renderPassDescriptor.colorAttachments[0].view = swapChain.getCurrentTexture().createView();
 
                 let passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
                 for (let i = 0; i < numCubes; ++i) {


### PR DESCRIPTION
Related to https://github.com/gpuweb/gpuweb/issues/1596, this PR updates the external WebGPU example to the latest (or almost latest) API, so that it's compatible with Firefox code in https://phabricator.services.mozilla.com/D110997